### PR TITLE
Fix wrangler syntax for namespace creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You need OAuth2 credentials from a Google account that has accessed Gemini. The 
 
 ```bash
 # Create a KV namespace for token caching
-wrangler kv:namespace create "GEMINI_CLI_KV"
+wrangler kv namespace create "GEMINI_CLI_KV"
 ```
 
 Note the namespace ID returned.


### PR DESCRIPTION
In wrangler 4.22.0, there's no `:` in the command to create the namespace.