### PR TITLE
Fix CORS in preflight requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ app.use("*", async (c, next) => {
 
 	// Handle preflight requests
 	if (c.req.method === "OPTIONS") {
-		return new Response(null, { status: 204 });
+		c.status(204);
+		return c.body(null);
 	}
 
 	await next();


### PR DESCRIPTION
The CORS headers were not being set for preflight requests (OPTIONS method). This issue causes Open WebUI to fail to fetch the available models. This PR fixes it.