### PR TITLE
Add model fallback on rate limit

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -26,3 +26,6 @@ ENABLE_REAL_THINKING=true
 # When enabled along with either thinking mode, reasoning will be streamed as regular content
 # wrapped in <thinking></thinking> tags instead of using the reasoning field
 STREAM_THINKING_AS_CONTENT=true
+
+# Optional: Auto switch from Pro to flash when you are getting ratelimited
+ENABLE_AUTO_MODEL_SWITCHING=true

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ npm run dev
 | `ENABLE_FAKE_THINKING` | ❌ | Enable synthetic thinking output for thinking models (set to "true" to enable) |
 | `ENABLE_REAL_THINKING` | ❌ | Enable real Gemini thinking output (set to "true" to enable) |
 | `STREAM_THINKING_AS_CONTENT` | ❌ | Stream thinking as content with `<thinking>` tags (DeepSeek R1 style) |
+| `ENABLE_AUTO_MODEL_SWITCHING` | ❌ | Enable automatic fallback from pro to flash models on rate limits (set to "true" to enable) |
 
 **Authentication Security:**
 - When `OPENAI_API_KEY` is set, all `/v1/*` endpoints require authentication
@@ -168,6 +169,13 @@ npm run dev
 - When `STREAM_THINKING_AS_CONTENT` is also set to "true", reasoning will be streamed as regular content wrapped in `<thinking></thinking>` tags (DeepSeek R1 style)
 - **Optimized UX**: The `</thinking>` tag is only sent when the actual LLM response begins, eliminating awkward pauses between thinking and response
 - If neither thinking mode is enabled, thinking models will behave like regular models
+
+**Auto Model Switching:**
+- When `ENABLE_AUTO_MODEL_SWITCHING` is set to "true", the system will automatically fall back from `gemini-2.5-pro` to `gemini-2.5-flash` when encountering rate limit errors (HTTP 429 or 503)
+- This provides seamless continuity when the Pro model quota is exhausted
+- The fallback is indicated in the response with a notification message
+- Only applies to supported model pairs (currently: pro → flash)
+- Works for both streaming and non-streaming requests
 
 ### KV Namespaces
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,3 +25,11 @@ export const DISABLED_THINKING_BUDGET = 0; // 0 disables thinking entirely
 
 // Generation config defaults
 export const DEFAULT_TEMPERATURE = 0.7;
+
+// Auto model switching configuration
+export const AUTO_SWITCH_MODEL_MAP = {
+	"gemini-2.5-pro": "gemini-2.5-flash"
+} as const;
+
+// HTTP status codes for rate limiting
+export const RATE_LIMIT_STATUS_CODES = [429, 503] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface Env {
 	ENABLE_FAKE_THINKING?: string; // Optional flag to enable fake thinking output (set to "true" to enable)
 	ENABLE_REAL_THINKING?: string; // Optional flag to enable real Gemini thinking output (set to "true" to enable)
 	STREAM_THINKING_AS_CONTENT?: string; // Optional flag to stream thinking as content with <thinking> tags (set to "true" to enable)
+	ENABLE_AUTO_MODEL_SWITCHING?: string; // Optional flag to enable automatic fallback from pro to flash on 429 errors (set to "true" to enable)
 }
 
 // --- OAuth2 Credentials Interface ---


### PR DESCRIPTION
This pull request introduces a new feature for automatic model switching to handle rate-limiting errors, along with supporting changes across the codebase. The feature ensures seamless fallback from a "Pro" model to a "Flash" model when rate limits are encountered, improving user experience during high-demand scenarios. Key updates include configuration additions, API client enhancements, and documentation updates.

### Feature: Auto Model Switching

#### Configuration and Constants
* Added `ENABLE_AUTO_MODEL_SWITCHING` to `.dev.vars.example` for enabling the feature and documented its purpose in `README.md`. [[1]](diffhunk://#diff-bf7a0c913b8a40afffb7c3ad128e8d8ef3413e648a9b3c4816ed1c57f7fd3a93R29-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R155) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R179)
* Introduced `AUTO_SWITCH_MODEL_MAP` for defining fallback model pairs and `RATE_LIMIT_STATUS_CODES` for identifying rate-limiting errors in `src/constants.ts`.

#### API Client Enhancements
* Updated `GeminiApiClient` to handle rate-limiting errors (HTTP 429/503) by switching to fallback models during both streaming and non-streaming requests. Added logic to notify users of the model switch. [[1]](diffhunk://#diff-8c1f22a912b5c4672a613e54847bb964a87bbc5e6a1b799018a9151451de9a13L408-R436) [[2]](diffhunk://#diff-8c1f22a912b5c4672a613e54847bb964a87bbc5e6a1b799018a9151451de9a13R572) [[3]](diffhunk://#diff-8c1f22a912b5c4672a613e54847bb964a87bbc5e6a1b799018a9151451de9a13R587-R630)
* Added helper methods `isAutoModelSwitchingEnabled` and `getFallbackModel` to encapsulate feature-specific logic.

### Documentation
* Expanded `README.md` with a new section explaining the auto model switching feature, its behavior, and supported model pairs.

### Codebase Integration
* Updated `Env` interface in `src/types.ts` to include the new `ENABLE_AUTO_MODEL_SWITCHING` flag.
* Imported new constants (`AUTO_SWITCH_MODEL_MAP`, `RATE_LIMIT_STATUS_CODES`) in `src/gemini-client.ts` for use in the API client logic.