### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Build & Style Check
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/GewoonJaap/gemini-cli-openai/security/code-scanning/2](https://github.com/GewoonJaap/gemini-cli-openai/security/code-scanning/2)

To fix the problem, we will add a `permissions` block at the root level of the workflow file. This block will define the minimal permissions required for the jobs in the workflow. Based on the steps in the workflow, it appears that the `contents: read` permission is sufficient, as the workflow primarily performs tasks such as checking out the code, installing dependencies, building the project, and running checks. None of these steps require write access to the repository.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
