### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/GewoonJaap/gemini-cli-openai/security/code-scanning/1](https://github.com/GewoonJaap/gemini-cli-openai/security/code-scanning/1)

To fix this issue, we will add a `permissions` block to the workflow. Since the workflow deploys a Cloudflare Worker, it does not require write access to the repository's contents. The minimal permissions required are `contents: read`. The `permissions` block will be added at the root level to limit the permissions for all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
