### PR TITLE
fix(api): correct safetySettings payload structure

### DIFF
--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -349,8 +349,7 @@ export class GeminiApiClient {
 			modelId,
 			req,
 			isRealThinkingEnabled,
-			includeReasoning,
-			this.env
+			includeReasoning
 		);
 
 		const { tools, toolConfig } = GenerationConfigValidator.createValidateTools(req);
@@ -362,6 +361,8 @@ export class GeminiApiClient {
 			needsThinkingClose = streamThinkingAsContent; // Only need to close if we streamed as content
 		}
 
+		const safetySettings = GenerationConfigValidator.createSafetySettings(this.env);
+
 		const streamRequest = {
 			model: modelId,
 			project: projectId,
@@ -369,7 +370,8 @@ export class GeminiApiClient {
 				contents: contents,
 				generationConfig,
 				tools: tools,
-				toolConfig
+				toolConfig,
+				...(safetySettings.length > 0 && { safetySettings })
 			}
 		};
 

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -361,19 +361,31 @@ export class GeminiApiClient {
 			needsThinkingClose = streamThinkingAsContent; // Only need to close if we streamed as content
 		}
 
-		const safetySettings = GenerationConfigValidator.createSafetySettings(this.env);
-
-		const streamRequest = {
+		const streamRequest: {
+			model: string;
+			project: string;
+			request: {
+				contents: unknown;
+				generationConfig: unknown;
+				tools: unknown;
+				toolConfig: unknown;
+				safetySettings?: unknown;
+			};
+		} = {
 			model: modelId,
 			project: projectId,
 			request: {
 				contents: contents,
 				generationConfig,
 				tools: tools,
-				toolConfig,
-				...(safetySettings.length > 0 && { safetySettings })
+				toolConfig
 			}
 		};
+
+		const safetySettings = GenerationConfigValidator.createSafetySettings(this.env);
+		if (safetySettings.length > 0) {
+			streamRequest.request.safetySettings = safetySettings;
+		}
 
 		yield* this.performStreamRequest(
 			streamRequest,

--- a/src/helpers/generation-config-validator.ts
+++ b/src/helpers/generation-config-validator.ts
@@ -126,8 +126,7 @@ export class GenerationConfigValidator {
 		modelId: string,
 		options: Partial<ChatCompletionRequest> = {},
 		isRealThinkingEnabled: boolean,
-		includeReasoning: boolean,
-		env?: Env
+		includeReasoning: boolean
 	): Record<string, unknown> {
 		const generationConfig: Record<string, unknown> = {
 			temperature: options.temperature ?? DEFAULT_TEMPERATURE,
@@ -141,14 +140,6 @@ export class GenerationConfigValidator {
 
 		if (options.response_format?.type === "json_object") {
 			generationConfig.responseMimeType = "application/json";
-		}
-
-		// Add safety settings if environment variables are provided
-		if (env) {
-			const safetySettings = this.createSafetySettings(env);
-			if (safetySettings.length > 0) {
-				generationConfig.safetySettings = safetySettings;
-			}
 		}
 
 		const modelInfo = geminiCliModels[modelId];

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 
 # --- KV Namespaces ---
 kv_namespaces = [
-  { binding = "GEMINI_CLI_KV", id = "6c761101b4a34c089e6a123f2782c5fd" }
+  { binding = "GEMINI_CLI_KV", id = "66de7b3778434ce199e0f90b186be8df" }
 ]
 
 # [vars]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 
 # --- KV Namespaces ---
 kv_namespaces = [
-  { binding = "GEMINI_CLI_KV", id = "66de7b3778434ce199e0f90b186be8df" }
+  { binding = "GEMINI_CLI_KV", id = "6c761101b4a34c089e6a123f2782c5fd" }
 ]
 
 # [vars]


### PR DESCRIPTION
The Gemini API expects the 'safetySettings' object to be a top-level property within the main request body, not nested inside 'generationConfig'.

This commit moves the 'safetySettings' object to the correct location in the stream request payload to resolve the 400 Bad Request error.