### PR TITLE
add Mutiple OAuth2 Profile, swith based on api key

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -11,7 +11,7 @@ GCP_SERVICE_ACCOUNT={"access_token":"ya29.a0AS3H6Nx...","refresh_token":"1//09Ft
 # When set, clients must include "Authorization: Bearer <your-api-key>" header
 # Example: sk-1234567890abcdef1234567890abcdef
 OPENAI_API_KEY=sk-your-secret-api-key-here
-
+GEMINI_PROJECT_MAP={"sk-key-0": {"GEMINI_PROJECT_ID": "xxxx","GCP_SERVICE_ACCOUNT":{"access_token":"ya29.a0AS3H6Nx...","refresh_token":"1//09FtpJYpxOd...","scope":"https://www.googleapis.com/auth/cloud-platform ...","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIs...","expiry_date":1750927763467}}, "sk-key-1": {"GEMINI_PROJECT_ID": "xxxx","GCP_SERVICE_ACCOUNT":{"access_token":"ya29.a0AS3H6Nx...","refresh_token":"1//09FtpJYpxOd...","scope":"https://www.googleapis.com/auth/cloud-platform ...","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIs...","expiry_date":1750927763467}}}
 # Optional: Enable fake thinking output for thinking models (set to "true" to enable)
 # When enabled, models marked with thinking: true will generate synthetic reasoning text
 # before providing their actual response, similar to OpenAI's o3 model behavior

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ npm run dev
 | `GCP_SERVICE_ACCOUNT` | ✅ | OAuth2 credentials JSON string. |
 | `GEMINI_PROJECT_ID` | ❌ | Google Cloud Project ID (auto-discovered if not set). |
 | `OPENAI_API_KEY` | ❌ | API key for authentication. If not set, the API is public. |
-
+| `GEMINI_PROJECT_MAP` | Mutiple OAuth2 Profile|
 #### Thinking & Reasoning
 
 | Variable | Description |

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface Env {
 	GCP_SERVICE_ACCOUNT: string; // Now contains OAuth2 credentials JSON
 	GEMINI_PROJECT_ID?: string;
 	GEMINI_CLI_KV: KVNamespace; // Cloudflare KV for token caching
+	GEMINI_PROJECT_MAP?: string;// Multiple auth profile
 	OPENAI_API_KEY?: string; // Optional API key for authentication
 	ENABLE_FAKE_THINKING?: string; // Optional flag to enable fake thinking output (set to "true" to enable)
 	ENABLE_REAL_THINKING?: string; // Optional flag to enable real Gemini thinking output (set to "true" to enable)


### PR DESCRIPTION
define `GEMINI_PROJECT_MAP`
```
GEMINI_PROJECT_MAP={"sk-key-0": {"GEMINI_PROJECT_ID": "xxxx","GCP_SERVICE_ACCOUNT":{"access_token":"ya29.a0AS3H6Nx...","refresh_token":"1//09FtpJYpxOd...","scope":"https://www.googleapis.com/auth/cloud-platform ...","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIs...","expiry_date":1750927763467}}, "sk-key-1": {"GEMINI_PROJECT_ID": "xxxx","GCP_SERVICE_ACCOUNT":{"access_token":"ya29.a0AS3H6Nx...","refresh_token":"1//09FtpJYpxOd...","scope":"https://www.googleapis.com/auth/cloud-platform ...","token_type":"Bearer","id_token":"eyJhbGciOiJSUzI1NiIs...","expiry_date":1750927763467}}}

```

run 
```bash
 curl localhost:8787/v1/chat/completions -H "Authorization : Bearer sk-key-0"  -H "Content-Type: application/json"   -d '{
    "model": "gemini-2.5-flash-lite",
    "messages": [
      {"role": "system", "content": "You are a helpful assistant."},
      {"role": "user", "content": "Hello, how are you?tell me a joke about earth"}
    ],
    "temperature": 0.7,
    "max_tokens": 150
  }'
```