### PR TITLE
Enhanced retry to wait returned rate limit if present

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,3 +101,6 @@ export const MIME_TYPE_MAP: Record<string, string> = {
 	wmv: "video/x-ms-wmv",
 	flv: "video/x-flv"
 };
+
+// rate limit higher than 60s means quota exhausted for the day for that specific model class (pro/flash)
+export const LONG_RESET_THRESHOLD_MS = 60000;

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -11,7 +11,12 @@ import {
 } from "./types";
 import { AuthManager } from "./auth";
 import { CODE_ASSIST_ENDPOINT, CODE_ASSIST_API_VERSION } from "./config";
-import { REASONING_MESSAGES, REASONING_CHUNK_DELAY, THINKING_CONTENT_CHUNK_SIZE, LONG_RESET_THRESHOLD_MS } from "./constants";
+import {
+	REASONING_MESSAGES,
+	REASONING_CHUNK_DELAY,
+	THINKING_CONTENT_CHUNK_SIZE,
+	LONG_RESET_THRESHOLD_MS
+} from "./constants";
 import { geminiCliModels } from "./models";
 import { validateContent } from "./utils/validation";
 import { GenerationConfigValidator } from "./helpers/generation-config-validator";
@@ -625,7 +630,7 @@ export class GeminiApiClient {
 						break;
 					}
 
-					if (dynamicDelay !== null) {
+					if (dynamicDelay !== null && attempt < retryDelays.length) {
 						console.log(`Got ${response.status} for ${currentModel}, waiting for quota reset: ${dynamicDelay}ms`);
 						await new Promise((resolve) => setTimeout(resolve, dynamicDelay));
 						continue;

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -619,7 +619,7 @@ export class GeminiApiClient {
 							}
 						}
 					} catch (e) {
-						console.log("Failed to parse rate limit error body, falling back to default retry delays.");
+						console.log("Failed to parse rate limit error body, falling back to default retry delays:", e);
 					}
 
 					if (isLongReset) {
@@ -627,12 +627,9 @@ export class GeminiApiClient {
 					}
 
 					if (dynamicDelay !== null) {
-						console.log(
-							`Got ${response.status} for ${currentModel}, waiting for quota reset: ${dynamicDelay}ms`
-						);
+						console.log(`Got ${response.status} for ${currentModel}, waiting for quota reset: ${dynamicDelay}ms`);
 						await new Promise((resolve) => setTimeout(resolve, dynamicDelay));
 						continue;
-
 					} else if (attempt < retryDelays.length) {
 						const delay = retryDelays[attempt];
 						console.log(

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -11,7 +11,7 @@ import {
 } from "./types";
 import { AuthManager } from "./auth";
 import { CODE_ASSIST_ENDPOINT, CODE_ASSIST_API_VERSION } from "./config";
-import { REASONING_MESSAGES, REASONING_CHUNK_DELAY, THINKING_CONTENT_CHUNK_SIZE } from "./constants";
+import { REASONING_MESSAGES, REASONING_CHUNK_DELAY, THINKING_CONTENT_CHUNK_SIZE, LONG_RESET_THRESHOLD_MS } from "./constants";
 import { geminiCliModels } from "./models";
 import { validateContent } from "./utils/validation";
 import { GenerationConfigValidator } from "./helpers/generation-config-validator";
@@ -608,8 +608,7 @@ export class GeminiApiClient {
 						if (errorData?.error?.message) {
 							const resetMs = this.autoSwitchHelper.parseQuotaResetTime(errorData.error.message);
 							if (resetMs !== null) {
-								// rate limit higher than 60s means quota exhausted for the day for that specific model class (pro/flash)
-								if (resetMs > 60000) {
+								if (resetMs > LONG_RESET_THRESHOLD_MS) {
 									isLongReset = true;
 									console.log(`Long quota reset detected (${resetMs}ms). Skipping retries to trigger fallback.`);
 								} else {

--- a/src/gemini-client.ts
+++ b/src/gemini-client.ts
@@ -599,7 +599,41 @@ export class GeminiApiClient {
 				}
 
 				if (this.autoSwitchHelper.isRateLimitStatus(response.status)) {
-					if (attempt < retryDelays.length) {
+					let dynamicDelay: number | null = null;
+					let isLongReset = false;
+
+					try {
+						const clonedResponse = response.clone();
+						const errorData = (await clonedResponse.json()) as { error?: { message?: string } };
+						if (errorData?.error?.message) {
+							const resetMs = this.autoSwitchHelper.parseQuotaResetTime(errorData.error.message);
+							if (resetMs !== null) {
+								// rate limit higher than 60s means quota exhausted for the day for that specific model class (pro/flash)
+								if (resetMs > 60000) {
+									isLongReset = true;
+									console.log(`Long quota reset detected (${resetMs}ms). Skipping retries to trigger fallback.`);
+								} else {
+									// small buffer just in case
+									dynamicDelay = resetMs + 1000;
+								}
+							}
+						}
+					} catch (e) {
+						console.log("Failed to parse rate limit error body, falling back to default retry delays.");
+					}
+
+					if (isLongReset) {
+						break;
+					}
+
+					if (dynamicDelay !== null) {
+						console.log(
+							`Got ${response.status} for ${currentModel}, waiting for quota reset: ${dynamicDelay}ms`
+						);
+						await new Promise((resolve) => setTimeout(resolve, dynamicDelay));
+						continue;
+
+					} else if (attempt < retryDelays.length) {
 						const delay = retryDelays[attempt];
 						console.log(
 							`Got ${response.status} for ${currentModel}, retrying in ${delay}ms (attempt ${attempt + 1}/${retryDelays.length})`

--- a/src/helpers/auto-model-switching.ts
+++ b/src/helpers/auto-model-switching.ts
@@ -45,6 +45,30 @@ export class AutoModelSwitchingHelper {
 	}
 
 	/**
+	 * Parses the quota reset time from a Gemini API error message.
+	 * Example message: "You have exhausted your capacity on this model. Your quota will reset after 20s."
+	 * Returns the reset time in milliseconds, or null if it cannot be parsed.
+	 * This is needed because apparently api doesn't return any rate-limit header
+	 */
+	parseQuotaResetTime(message: string): number | null {
+		const match = message.match(/reset after (.*?)\./);
+		if (!match) return null;
+
+		const durationStr = match[1];
+		let totalMs = 0;
+
+		const hours = durationStr.match(/(\d+)h/);
+		const minutes = durationStr.match(/(\d+)m/);
+		const seconds = durationStr.match(/(\d+)s/);
+
+		if (hours) totalMs += parseInt(hours[1]) * 60 * 60 * 1000;
+		if (minutes) totalMs += parseInt(minutes[1]) * 60 * 1000;
+		if (seconds) totalMs += parseInt(seconds[1]) * 1000;
+
+		return totalMs > 0 ? totalMs : null;
+	}
+
+	/**
 	 * Determines if fallback should be attempted for the given model and conditions.
 	 */
 	shouldAttemptFallback(originalModel: string): boolean {

--- a/src/helpers/auto-model-switching.ts
+++ b/src/helpers/auto-model-switching.ts
@@ -61,9 +61,9 @@ export class AutoModelSwitchingHelper {
 		const minutes = durationStr.match(/(\d+)m/);
 		const seconds = durationStr.match(/(\d+)s/);
 
-		if (hours) totalMs += parseInt(hours[1]) * 60 * 60 * 1000;
-		if (minutes) totalMs += parseInt(minutes[1]) * 60 * 1000;
-		if (seconds) totalMs += parseInt(seconds[1]) * 1000;
+		if (hours) totalMs += parseInt(hours[1], 10) * 60 * 60 * 1000;
+		if (minutes) totalMs += parseInt(minutes[1], 10) * 60 * 1000;
+		if (seconds) totalMs += parseInt(seconds[1], 10) * 1000;
 
 		return totalMs > 0 ? totalMs : null;
 	}


### PR DESCRIPTION
## Changes
- enhanced auto-retry to wait the returned rate limit from gemini api (if present).
- added parseQuotaResetTime to parse rate limit from gemini api response.
NOTE: implementation uses a regex on error message because gemini api doesn't return a rate-limit header